### PR TITLE
Adding functionality/fixes in pivot_tricot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: instatExtras
 Title: A set of functions used in R-Instat
-Version: 0.2.3.8
+Version: 0.2.3.9
 Authors@R: c(
     person("Danny", "Parsons", , role = "aut"),
     person("Lily", "Clements", , "lily@idems.international", role = c("aut", "cre"),

--- a/R/detect_tricot_structure.R
+++ b/R/detect_tricot_structure.R
@@ -1,68 +1,76 @@
 #' Detect Tricot Data Structure
 #'
-#' Identifies option columns, good/bad trait columns, and rank values within a tricot dataset based on naming conventions.
+#' Identifies option columns, trait columns (good/bad), and rank values in a tricot dataset based on naming conventions.
 #'
-#' @param data A data frame that may contain tricot trial data.
-#' @param prefix Character vector of suffixes that indicate trait-data (default `NULL`)
-#' @param good_suffixes Character vector of suffixes that indicate positively ranked traits (default: `"_pos"`, `"_best"`).
-#' @param bad_suffixes Character vector of suffixes that indicate negatively ranked traits (default: `"_neg"`, `"_worst"`).
-#' @param na_candidates Character vector of values to treat as missing (default includes `"Not observed"`).
+#' @param data A data frame containing tricot trial data.
+#' @param variety_cols Optional character vector of column names for option sets (e.g., c("option_a", "option_b", "option_c")). Autodetected by suffix `_a`, `_b`, `_c` if `NULL`.
+#' @param rank_values Character vector of possible rank values (e.g., `c("A", "B", "C")`). If `NULL`, inferred from observed trait values.
+#' @param prefix Optional character string used to filter option columns by a common prefix before `_a`, `_b`, `_c` when autodetecting.
+#' @param good_suffixes Character vector of suffixes indicating positively ranked traits (default: `c("_pos", "_best", "best")`).
+#' @param bad_suffixes Character vector of suffixes indicating negatively ranked traits (default: `c("_neg", "_worst", "worst")`).
+#' @param na_candidates Character vector of values to treat as missing (default: `c("Not observed", "Not scored", NA_character_)`).
 #'
-#' @return A list with the following elements:
+#' @return A list with the following components:
 #' \describe{
-#'   \item{option_cols}{Vector of column names matching `_a`, `_b`, or `_c` pattern for options.}
-#'   \item{ranks}{Unique ranking values detected (excluding `na_candidates`).}
-#'   \item{trait_good_cols}{Suffixes of columns identified as good trait responses.}
-#'   \item{trait_bad_cols}{Suffixes of columns identified as bad trait responses.}
-#'   \item{na_candidates}{The `na_candidates` input, for reference.}
+#'   \item{option_cols}{Character vector of detected or specified option columns.}
+#'   \item{ranks}{Character vector of rank values used to order options.}
+#'   \item{trait_good_cols}{Character vector of detected suffixes for good traits.}
+#'   \item{trait_bad_cols}{Character vector of detected suffixes for bad traits.}
+#'   \item{na_candidates}{The original `na_candidates` vector, for reference.}
 #' }
 #'
 #' @examples
 #' df <- data.frame(
 #'   id = 1:3,
-#'   option_a = c("x", "y", "z"),
+#'   option_a   = c("x", "y", "z"),
 #'   colour_pos = c("A", "B", "C"),
-#'   taste_neg = c("C", "B", "Not observed")
+#'   taste_neg  = c("C", "B", "Not observed")
 #' )
 #' detect_tricot_structure(df)
 #'
 #' @export
 detect_tricot_structure <- function(data,
+                                    variety_cols = NULL,
+                                    rank_values = c("A", "B", "C"),
                                     prefix = NULL,
                                     good_suffixes = c("_pos", "_best", "best"),
                                     bad_suffixes = c("_neg", "_worst", "worst"),
                                     na_candidates = c("Not observed", "Not scored", NA_character_)) {
   
-  # 1. Option columns (ending in _a/_b/_c or similar)
-  if (!is.null(prefix)) {
-    # If a prefix is provided, use it
-    option_cols <- names(data)[grepl(paste0("^", prefix, "_[abc]$"), names(data), ignore.case = TRUE)]
-  } else {
-    # Otherwise, collect all columns ending in _a/_b/_c
-    option_cols <- names(data)[grepl("_[abc]$", names(data), ignore.case = TRUE)]
-    
-    # Extract just the base part before _a/_b/_c
-    base_names <- sub("_[abc]$", "", option_cols, ignore.case = TRUE)
-    
-    # Count how many times each base name appears
-    base_counts <- table(base_names)
-    
-    # If multiple sets (e.g., var_a, var_b, var_c), try to prioritise based on known prefixes
-    if (length(base_counts) > 1) {
-      likely_prefixes <- c("variety", "option")
+  # Get the names of our variety/option columns
+  # This can be specified or autodetected.
+  if (is.null(variety_cols)){ # Autodetect (else variety_cols = a list of the columns)
+    if (!is.null(prefix)) {
+      # If a prefix is provided, use it
+      variety_cols <- names(data)[grepl(paste0("^", prefix, "_[abc]$"), names(data), ignore.case = TRUE)]
+    } else {
+      # Otherwise, collect all columns ending in _a/_b/_c
+      variety_cols <- names(data)[grepl("_[abc]$", names(data), ignore.case = TRUE)]
       
-      # Choose bases that start with likely prefix
-      preferred_bases <- names(base_counts)[base_counts >= 3 & grepl(paste(likely_prefixes, collapse = "|"), names(base_counts), ignore.case = TRUE)]
+      # Extract just the base part before _a/_b/_c
+      base_names <- sub("_[abc]$", "", variety_cols, ignore.case = TRUE)
       
-      # If any preferred sets found, filter option_cols to just those
-      if (length(preferred_bases) > 0) {
-        option_cols <- option_cols[sub("_[abc]$", "", option_cols, ignore.case = TRUE) %in% preferred_bases]
+      # Count how many times each base name appears
+      base_counts <- table(base_names)
+      
+      # If multiple sets (e.g., var_a, var_b, var_c), try to prioritise based on known prefixes
+      if (length(base_counts) > 1) {
+        likely_prefixes <- c("variety", "option")
+        
+        # Choose bases that start with likely prefix
+        preferred_bases <- names(base_counts)[base_counts >= 3 & grepl(paste(likely_prefixes, collapse = "|"), names(base_counts), ignore.case = TRUE)]
+        
+        # If any preferred sets found, filter variety_cols to just those
+        if (length(preferred_bases) > 0) {
+          variety_cols <- variety_cols[sub("_[abc]$", "", variety_cols, ignore.case = TRUE) %in% preferred_bases]
+        }
       }
     }
   }
 
   
-  # 2. Trait columns ending in _pos/_neg/_best/_worst
+  # 2. Trait columns: Get the names of our traits
+  # always ending in _pos/_neg/_best/_worst
   good_matched <- purrr::map_dfr(names(data), function(col) {
     matched_suffix <- good_suffixes[endsWith(col, good_suffixes)]
     
@@ -93,16 +101,18 @@ detect_tricot_structure <- function(data,
     }
   })
   
-  rank_values <- setdiff(unlist(good_matched$values), na_candidates)
-  
-  # Extract suffixes from option_cols (e.g., "a", "b", "c")
-  suffix_order <- sub(".*_", "", option_cols)
-  
-  # Reorder ranks based on matching lowercase suffixes
-  rank_values <- rank_values[match(toupper(suffix_order), rank_values)]
+  if (is.null(rank_values)){
+    rank_values <- setdiff(unlist(good_matched$values), na_candidates)
+    
+    # Extract suffixes from variety_cols (e.g., "a", "b", "c")
+    suffix_order <- sub(".*_", "", variety_cols)
+    
+    # Reorder ranks based on matching lowercase suffixes
+    rank_values <- rank_values[match(toupper(suffix_order), rank_values)]
+  }
   
   list(
-    option_cols = option_cols,
+    option_cols = variety_cols,
     ranks = rank_values,
     trait_good_cols = unique(good_matched$suffix),
     trait_bad_cols = unique(bad_matched$suffix),

--- a/R/pivot_tricot.R
+++ b/R/pivot_tricot.R
@@ -147,7 +147,7 @@ pivot_tricot <- function(data = NULL,
         data_options_b <- data_options_b %>%
           dplyr::full_join(ranked) %>%
           dplyr::group_by(!!id_data_sym, trait) %>%
-          dplyr::mutate(variety = ifelse(is.na(variety), setdiff(possible_ranks, variety)[1], variety)) %>%
+          dplyr::mutate(variety = dplyr::if_else(is.na(variety), setdiff(possible_ranks, variety)[1], variety)) %>%
           dplyr::ungroup() %>%
           dplyr::arrange(!!id_data_sym, trait) %>% 
           dplyr::rename(dummy_variety = variety) %>%

--- a/R/pivot_tricot.R
+++ b/R/pivot_tricot.R
@@ -2,216 +2,179 @@
 #'
 #' Transforms Tricot (Triadic Comparison of Technologies) data into a tidy format,
 #' assigning ranks to varieties based on trait evaluations.  Supports input either
-#' as a single ID-level dataset (`data`) with option columns and trait indicators,
-#' or as a plot–trait–level dataset (`data_plot_trait`) with explicit variety,
+#' as a single ID-level dataset (data) with option columns and trait indicators,
+#' or as a plot–trait–level dataset (data_plot_trait) with explicit variety,
 #' trait, and rank columns, or both.
 #'
 #' @param data A data frame containing ID-level Tricot data.  Must include an ID column
-#'   (`data_id_col`) and three option columns (`option_cols`), plus trait indicator
-#'   columns ending in `trait_good` or `trait_bad`, unless `data_plot_trait` is provided.
-#' @param data_id_col Character string naming the ID column in `data`.  Default is `"id"`.
+#'   (data_id_col) and three option columns (option_cols), plus trait indicator
+#'   columns ending in trait_good or trait_bad, unless data_plot_trait is provided.
+#' @param data_id_col Character string naming the ID column in data.  Default is "id".
 #' @param data_trait_cols Optional character vector of specific trait-indicator columns
-#'   in `data` to restrict scanning (overrides automatic selection by suffix).  Default `NULL`.
-#' @param carry_cols Optional character vector of column names in `data` to carry along
-#'   into the output (e.g. blocking factors, metadata).  Default `NULL`.
+#'   in data to restrict scanning (overrides automatic selection by suffix).  Default NULL.
+#' @param carry_cols Optional character vector of column names in data to carry along
+#'   into the output (e.g. blocking factors, metadata).  Default NULL.
 #' @param data_plot_trait A data frame in “plot–trait” format containing one row per
-#'   (ID, variety, trait) with an associated `rank_col`.  Default `NULL`.
+#'   (ID, variety, trait) with an associated rank_col.  Default NULL.
 #' @param data_plot_trait_id_col Character string naming the ID column in
-#'   `data_plot_trait`.  Default is `"id"`.
-#' @param variety_col Character string naming the variety column in `data_plot_trait`.
-#' @param trait_col Character string naming the trait column in `data_plot_trait`.
-#' @param rank_col Character string naming the rank column in `data_plot_trait`.
+#'   data_plot_trait.  Default is "id".
+#' @param variety_col Character string naming the variety column in data_plot_trait.
+#' @param trait_col Character string naming the trait column in data_plot_trait.
+#' @param rank_col Character string naming the rank column in data_plot_trait.
 #' @param option_cols Character vector of length three naming the option columns in
-#'   `data` (e.g. `c("option_a", "option_b", "option_c")`).  Default is
-#'   `c("option_a", "option_b", "option_c")`.
-#' @param possible_ranks Character vector of labels corresponding to `option_cols`
-#'   (e.g. `c("A", "B", "C")`).  Default is `c("A", "B", "C")`.
-#' @param trait_good Suffix (or full name) identifying columns in `data` where a
-#'   variety is positively ranked for a trait (e.g. `"_pos"` or `"best"`).  Default `"_pos"`.
-#' @param trait_bad Suffix (or full name) identifying columns in `data` where a
-#'   variety is negatively ranked for a trait (e.g. `"_neg"` or `"worst"`).  Default `"_neg"`.
-#' @param na_value Value used in `data` to indicate a missing or unobserved trait.
-#'   Default is `"Not observed"`.
+#'   data (e.g. c("option_a", "option_b", "option_c")).  Default is
+#'   c("option_a", "option_b", "option_c").
+#' @param possible_ranks Character vector of labels corresponding to option_cols
+#'   (e.g. c("A", "B", "C")).  Default is c("A", "B", "C").
+#' @param trait_good Suffix (or full name) identifying columns in data where a
+#'   variety is positively ranked for a trait (e.g. "_pos" or "best").  Default "_pos".
+#' @param trait_bad Suffix (or full name) identifying columns in data where a
+#'   variety is negatively ranked for a trait (e.g. "_neg" or "worst").  Default "_neg".
+#' @param na_value Value used in data to indicate a missing or unobserved trait.
+#'   Default is "Not observed".
 #'
 #' @return A tibble in tidy format with one row per (ID, trait, variety) combination,
-#'   containing at least the following columns:
+#' containing at least the following columns:
 #'   \describe{
-#'     \item{id}{Identifier for each trial or plot.}
-#'     \item{dummy_variety}{Factor-coded option label corresponding to the variety (e.g. `"A"`, `"B"`, `"C"`).}
-#'     \item{trait}{Name of the trait being ranked (when `data` input used).}
+#'     \item{<data_id_col>}{Identifier for each trial or plot (column name retained).}
+#'     \item{dummy_variety}{Factor-coded option label corresponding to the variety (e.g. "A", "B", "C").}
+#'     \item{trait}{Name of the trait being ranked (when data input used).}
 #'     \item{rank}{Numeric or character rank assigned to the variety.}
 #'     \item{variety}{Name of the variety or option.}
-#'     \item{<carry_cols>}{Any additional columns specified via `carry_cols`, carried through from `data`.}
+#'     \item{<carry_cols>}{Any additional columns specified via carry_cols, carried through from data.}
 #'   }
-#'   Additional trait-specific columns will appear if both `data` and
-#'   `data_plot_trait` are provided.
-#'
-#' @examples
-#' # Using ID-level data only, carrying a blocking factor
-#' df <- data.frame(
-#'   id         = 1:3,
-#'   block      = rep(1:3),
-#'   option_a   = c("x", "y", "z"),
-#'   option_b   = c("u", "v", "w"),
-#'   option_c   = c("m", "n", "o"),
-#'   colour_pos = c("A", "B", "C"),
-#'   taste_neg  = c("C", "B", "Not observed")
-#' )
-#' pivot_tricot(
-#'   data         = df,
-#'   data_id_col  = "id",
-#'   carry_cols   = "block",
-#'   option_cols  = c("option_a", "option_b", "option_c"),
-#'   trait_good   = "_pos",
-#'   trait_bad    = "_neg"
-#' )
-#'
-#' # Using plot–trait–level data only
-#' df_trait <- data.frame(
-#'   id     = rep(1:2, each = 3),
-#'   item   = rep(c("x","y","z"), times = 2),
-#'   trait  = rep("colour", 6),
-#'   rank   = rep(1:3, times = 2)
-#' )
-#' pivot_tricot(
-#'   data_plot_trait       = df_trait,
-#'   data_plot_trait_id_col = "id",
-#'   variety_col            = "item",
-#'   trait_col              = "trait",
-#'   rank_col               = "rank"
-#' )
+#'   Additional trait-specific columns will appear if both data and
+#'   data_plot_trait are provided.
 #'
 #' @export
-pivot_tricot <- function(data = NULL, data_id_col = "id", data_trait_cols = NULL,
+pivot_tricot <- function(data = NULL,
+                         data_id_col = "id",
+                         data_trait_cols = NULL,
                          carry_cols = NULL,
-                         data_plot_trait = NULL, data_plot_trait_id_col = "id",
+                         data_plot_trait = NULL,
+                         data_plot_trait_id_col = "id",
                          variety_col = NULL,
-                         trait_col = NULL, rank_col = NULL,
+                         trait_col = NULL,
+                         rank_col = NULL,
                          option_cols = c("option_a", "option_b", "option_c"),
-                         possible_ranks = c("A", "B", "C"), trait_good = "_pos", 
-                         trait_bad = "_neg", na_value = "Not observed") {
+                         possible_ranks = c("A", "B", "C"),
+                         trait_good = "_pos",
+                         trait_bad = "_neg",
+                         na_value = "Not observed") {
   
   # Input checks
-  if (is.null(data) & is.null(data_plot_trait)) {
-    stop("At least one of `data` or `data_plot_trait` must be provided.")
+  if (is.null(data) && is.null(data_plot_trait)) {
+    stop("At least one of data or data_plot_trait must be provided.")
   }
-  
-  if (!is.null(data) & is.null(data_id_col)) {
-    stop("If `data` is provided, `data_id_col` must also be specified.")
+  if (!is.null(data) && is.null(data_id_col)) {
+    stop("If data is provided, data_id_col must also be specified.")
   }
-  
   if (!is.null(data_plot_trait)) {
-    if (is.null(data_plot_trait_id_col) | is.null(variety_col) | is.null(trait_col) | is.null(rank_col)) {
-      stop("If `data_plot_trait` is provided, then `data_plot_trait_id_col`, `variety_col`, `trait_col`, and `rank_col` must also be provided.")
+    if (is.null(data_plot_trait_id_col) || is.null(variety_col) || is.null(trait_col) || is.null(rank_col)) {
+      stop("If data_plot_trait is provided, then data_plot_trait_id_col, variety_col, trait_col, and rank_col must also be provided.")
     }
   }
   
-  # Handle data_plot_trait if relevant columns are given
-  if (!is.null(variety_col) & !is.null(trait_col) & !is.null(rank_col)) {
-    
+  # Helpers for tidy evaluation
+  id_data_sym <- rlang::sym(data_id_col)
+  id_plot_sym <- rlang::sym(data_plot_trait_id_col)
+  
+  # Process data_plot_trait
+  if (!is.null(data_plot_trait)) {
     data_options_a <- data_plot_trait %>%
-      tidyr::pivot_wider(names_from = dplyr::all_of(trait_col),
+      tidyr::pivot_wider(names_from   = dplyr::all_of(trait_col),
                          values_from = dplyr::all_of(rank_col))
-    
-    lookup <- c(id = data_plot_trait_id_col, variety = variety_col)
-    data_options_a <- dplyr::rename(data_options_a, dplyr::all_of(lookup))
   }
   
-  # Handle data
+  # Process data
   if (!is.null(data)) {
-    
-    # if they specify which traits, then run this
-    if (!is.null(data_trait_cols)){
+    # Select trait indicator columns
+    if (!is.null(data_trait_cols)) {
       matching_cols <- data %>% dplyr::select(dplyr::all_of(data_trait_cols))
     } else {
       matching_cols <- data %>% dplyr::select(dplyr::ends_with(trait_good), dplyr::ends_with(trait_bad))
     }
     
+    # Map option labels to ranks
     label_map <- stats::setNames(option_cols, possible_ranks)
+    
+    # Pivot options to long format, retaining original ID column name
     data_options <- data %>%
-      dplyr::mutate(id = data[[data_id_col]]) %>% 
-      tidyr::pivot_longer(cols = dplyr::all_of(option_cols), names_to = "Label", values_to = "variable") %>% 
+      dplyr::mutate(!!id_data_sym := .data[[data_id_col]]) %>%
+      tidyr::pivot_longer(cols       = dplyr::all_of(option_cols),
+                          names_to   = "Label",
+                          values_to  = "variable") %>%
       dplyr::mutate(Label = forcats::fct_recode(Label, !!!label_map))
     
     data_options_id <- data_options %>%
-      dplyr::select(c(id,
-                      dplyr::all_of(carry_cols),
-                      variety = variable,
-                      dummy_variety = Label)) %>%
+      dplyr::select(dplyr::all_of(c(data_id_col, carry_cols)),
+                    variety       = variable,
+                    dummy_variety = Label) %>%
       unique()
     
     if (ncol(matching_cols) > 0) {
-      data_options <- data %>% dplyr::mutate(id = data[[data_id_col]]) %>% 
-        tidyr::pivot_longer(cols = dplyr::all_of(names(matching_cols)), names_to = "trait", 
+      # Convert trait indicators into ranks
+      data_options_b <- data %>%
+        dplyr::mutate(!!id_data_sym := .data[[data_id_col]]) %>%
+        tidyr::pivot_longer(cols      = dplyr::all_of(names(matching_cols)),
+                            names_to  = "trait",
                             values_to = "variety") %>%
-        dplyr::select(c(id, trait, variety)) %>%
-        dplyr::mutate(rank = ifelse(grepl(trait_good, trait), 1, 3)) %>%
-        dplyr::mutate(trait = sub("(_[^_]*)$", "", trait))
+        dplyr::select(!!id_data_sym, trait, variety) %>%
+        dplyr::mutate(rank = ifelse(grepl(trait_good, trait), 1, 3),
+                      trait = sub("(_[^_]*)$", "", trait))
+      
+      # Handle middle ranks and reshape
       if (ncol(matching_cols) == 2) {
-        data_options_b <- data_options %>% dplyr::group_by(id) %>% 
-          dplyr::summarise(missing_var = setdiff(possible_ranks, 
-                                                 variety), .groups = "drop") %>%
+        missing_mid <- data_options_b %>%
+          dplyr::group_by(!!id_data_sym) %>%
+          dplyr::summarise(missing_var = setdiff(possible_ranks, variety), .groups = "drop") %>%
           dplyr::mutate(trait = "middle", rank = 2) %>%
-          dplyr::rename(variety = missing_var) %>% 
-          dplyr::bind_rows(data_options) %>%
-          dplyr::arrange(id, rank) %>%
-          dplyr::mutate(trait = rank) %>% 
-          dplyr::select(-c("rank")) %>%
-          dplyr::rename(dummy_variety = "variety")
-        data_options_b <- dplyr::full_join(data_options_id, data_options_b)
+          dplyr::rename(variety = missing_var)
+        
+        data_options_b <- dplyr::bind_rows(data_options_b, missing_mid) %>%
+          dplyr::arrange(!!id_data_sym, rank) %>%
+          dplyr::rename(dummy_variety = variety) %>%
+          dplyr::full_join(data_options_id)
       } else {
-        data_options <- data_options %>%
-          dplyr::filter(!is.na(variety)) %>%
-          dplyr::group_by(id, trait) %>%
-          dplyr::mutate(variety = if (dplyr::n_distinct(variety) == 1) NA else variety) %>%
-          dplyr::filter(!is.na(variety)) %>%
-          dplyr::ungroup() %>%
-          unique()
+        # General case for >=3 traits
+        ranked <- data_options_b %>%
+          dplyr::filter(!is.na(variety) & variety != na_value) %>%
+          dplyr::count(!!id_data_sym, trait) %>%
+          dplyr::filter(n == 2) %>%
+          dplyr::mutate(rank = 2)
         
-        rank_2 <- data_options %>%
-          dplyr::group_by(id, trait) %>%
-          dplyr::filter(variety != na_value) %>%
-          dplyr::count() %>%
-          dplyr::mutate(rank = 2) %>%
-          dplyr::filter(n == 2)
-        
-        data_options_b <- data_options %>%
-          dplyr::full_join(rank_2) %>%
-          dplyr::group_by(id, trait) %>%
+        data_options_b <- data_options_b %>%
+          dplyr::full_join(ranked) %>%
+          dplyr::group_by(!!id_data_sym, trait) %>%
           dplyr::mutate(variety = ifelse(is.na(variety), setdiff(possible_ranks, variety)[1], variety)) %>%
           dplyr::ungroup() %>%
-          dplyr::arrange(id, trait) %>%
           dplyr::rename(dummy_variety = variety) %>%
           dplyr::full_join(data_options_id) %>%
-          dplyr::select(c(id, trait, rank, variety, dplyr::all_of(carry_cols), dummy_variety)) %>%
+          dplyr::select(dplyr::all_of(c(data_id_col, carry_cols)), trait, rank, variety, dummy_variety) %>%
           tidyr::pivot_wider(names_from = trait, values_from = rank) %>%
           dplyr::filter(!is.na(variety))
       }
     } else {
-      if (!is.null(data_plot_trait)){
+      if (!is.null(data_plot_trait)) {
         data_options_a <- dplyr::full_join(data_options_a, data_options_id)
       } else {
-        stop(paste0("No columns ending with ", trait_good, " or ", trait_bad, " found in `data`."))
+        stop(paste0("No columns ending with ", trait_good, " or ", trait_bad, " found in data."))
       }
     }
   }
   
-  # Combine if both datasets are available
-  if ((!is.null(data) & !is.null(data_plot_trait)) && ncol(matching_cols) > 0) {
-    message("Using both `data` and `data_plot_trait`")
-    
+  # Combine data and plot-trait if both provided
+  if (!is.null(data) && !is.null(data_plot_trait) && ncol(matching_cols) > 0) {
+    message("Using both data and data_plot_trait")
     data_options <- dplyr::full_join(data_options_a, data_options_b)
     
-    if (nrow(data_options_a) == nrow(data_options_b)) {
-      if (nrow(data_options) != nrow(data_options_a)) {
-        IDs_to_check <- data_options %>%
-          dplyr::group_by(id) %>%
-          dplyr::count() %>%
-          dplyr::filter(n > 3) %>%
-          dplyr::pull(id)
-        warning("Using both data frames has caused repeats in trait columns.\nSome traits in `data` differ from `data_plot_trait` for the same ID and variety combination.\nCheck IDs: ",
-                paste0(IDs_to_check, collapse = ", "))
-      }
+    if (nrow(data_options_a) == nrow(data_options_b) && nrow(data_options) != nrow(data_options_a)) {
+      bad_ids <- data_options %>%
+        dplyr::group_by(!!id_data_sym) %>%
+        dplyr::count() %>%
+        dplyr::filter(n > length(option_cols)) %>%
+        dplyr::pull(!!id_data_sym)
+      warning("Repeating entries for IDs: ", paste(bad_ids, collapse = ", "))
     }
   } else if (!is.null(data_plot_trait)) {
     data_options <- data_options_a

--- a/R/pivot_tricot.R
+++ b/R/pivot_tricot.R
@@ -137,7 +137,7 @@ pivot_tricot <- function(data = NULL,
           dplyr::rename(dummy_variety = "variety")
         data_options_b <- dplyr::full_join(data_options_id, data_options_b)
       } else {
-        # General case for >=3 traits
+        # General case 
         ranked <- data_options_b %>%
           dplyr::filter(!is.na(variety) & variety != na_value) %>%
           dplyr::count(!!id_data_sym, trait) %>%
@@ -149,6 +149,7 @@ pivot_tricot <- function(data = NULL,
           dplyr::group_by(!!id_data_sym, trait) %>%
           dplyr::mutate(variety = ifelse(is.na(variety), setdiff(possible_ranks, variety)[1], variety)) %>%
           dplyr::ungroup() %>%
+          dplyr::arrange(!!id_data_sym, trait) %>% 
           dplyr::rename(dummy_variety = variety) %>%
           dplyr::full_join(data_options_id) %>%
           dplyr::select(dplyr::all_of(c(data_id_col, carry_cols)), trait, rank, variety, dummy_variety) %>%

--- a/R/pivot_tricot.R
+++ b/R/pivot_tricot.R
@@ -130,11 +130,12 @@ pivot_tricot <- function(data = NULL,
           dplyr::summarise(missing_var = setdiff(possible_ranks, variety), .groups = "drop") %>%
           dplyr::mutate(trait = "middle", rank = 2) %>%
           dplyr::rename(variety = missing_var)
-        
         data_options_b <- dplyr::bind_rows(data_options_b, missing_mid) %>%
           dplyr::arrange(!!id_data_sym, rank) %>%
-          dplyr::rename(dummy_variety = variety) %>%
-          dplyr::full_join(data_options_id)
+          dplyr::mutate(trait = rank) %>% 
+          dplyr::select(-c("rank")) %>%
+          dplyr::rename(dummy_variety = "variety")
+        data_options_b <- dplyr::full_join(data_options_id, data_options_b)
       } else {
         # General case for >=3 traits
         ranked <- data_options_b %>%

--- a/man/detect_tricot_structure.Rd
+++ b/man/detect_tricot_structure.Rd
@@ -6,6 +6,8 @@
 \usage{
 detect_tricot_structure(
   data,
+  variety_cols = NULL,
+  rank_values = c("A", "B", "C"),
   prefix = NULL,
   good_suffixes = c("_pos", "_best", "best"),
   bad_suffixes = c("_neg", "_worst", "worst"),
@@ -13,35 +15,39 @@ detect_tricot_structure(
 )
 }
 \arguments{
-\item{data}{A data frame that may contain tricot trial data.}
+\item{data}{A data frame containing tricot trial data.}
 
-\item{prefix}{Character vector of suffixes that indicate trait-data (default \code{NULL})}
+\item{variety_cols}{Optional character vector of column names for option sets (e.g., c("option_a", "option_b", "option_c")). Autodetected by suffix \verb{_a}, \verb{_b}, \verb{_c} if \code{NULL}.}
 
-\item{good_suffixes}{Character vector of suffixes that indicate positively ranked traits (default: \code{"_pos"}, \code{"_best"}).}
+\item{rank_values}{Character vector of possible rank values (e.g., \code{c("A", "B", "C")}). If \code{NULL}, inferred from observed trait values.}
 
-\item{bad_suffixes}{Character vector of suffixes that indicate negatively ranked traits (default: \code{"_neg"}, \code{"_worst"}).}
+\item{prefix}{Optional character string used to filter option columns by a common prefix before \verb{_a}, \verb{_b}, \verb{_c} when autodetecting.}
 
-\item{na_candidates}{Character vector of values to treat as missing (default includes \code{"Not observed"}).}
+\item{good_suffixes}{Character vector of suffixes indicating positively ranked traits (default: \code{c("_pos", "_best", "best")}).}
+
+\item{bad_suffixes}{Character vector of suffixes indicating negatively ranked traits (default: \code{c("_neg", "_worst", "worst")}).}
+
+\item{na_candidates}{Character vector of values to treat as missing (default: \code{c("Not observed", "Not scored", NA_character_)}).}
 }
 \value{
-A list with the following elements:
+A list with the following components:
 \describe{
-\item{option_cols}{Vector of column names matching \verb{_a}, \verb{_b}, or \verb{_c} pattern for options.}
-\item{ranks}{Unique ranking values detected (excluding \code{na_candidates}).}
-\item{trait_good_cols}{Suffixes of columns identified as good trait responses.}
-\item{trait_bad_cols}{Suffixes of columns identified as bad trait responses.}
-\item{na_candidates}{The \code{na_candidates} input, for reference.}
+\item{option_cols}{Character vector of detected or specified option columns.}
+\item{ranks}{Character vector of rank values used to order options.}
+\item{trait_good_cols}{Character vector of detected suffixes for good traits.}
+\item{trait_bad_cols}{Character vector of detected suffixes for bad traits.}
+\item{na_candidates}{The original \code{na_candidates} vector, for reference.}
 }
 }
 \description{
-Identifies option columns, good/bad trait columns, and rank values within a tricot dataset based on naming conventions.
+Identifies option columns, trait columns (good/bad), and rank values in a tricot dataset based on naming conventions.
 }
 \examples{
 df <- data.frame(
   id = 1:3,
-  option_a = c("x", "y", "z"),
+  option_a   = c("x", "y", "z"),
   colour_pos = c("A", "B", "C"),
-  taste_neg = c("C", "B", "Not observed")
+  taste_neg  = c("C", "B", "Not observed")
 )
 detect_tricot_structure(df)
 

--- a/man/pivot_tricot.Rd
+++ b/man/pivot_tricot.Rd
@@ -7,6 +7,8 @@
 pivot_tricot(
   data = NULL,
   data_id_col = "id",
+  data_trait_cols = NULL,
+  carry_cols = NULL,
   data_plot_trait = NULL,
   data_plot_trait_id_col = "id",
   variety_col = NULL,
@@ -20,92 +22,100 @@ pivot_tricot(
 )
 }
 \arguments{
-\item{data}{A data frame containing option columns and trait ranking indicators (e.g. columns ending in \verb{_pos} or \verb{_neg}).}
+\item{data}{A data frame containing ID-level Tricot data.  Must include an ID column
+(\code{data_id_col}) and three option columns (\code{option_cols}), plus trait indicator
+columns ending in \code{trait_good} or \code{trait_bad}, unless \code{data_plot_trait} is provided.}
 
-\item{data_id_col}{The name of the ID column in \code{data}. Default is \code{"id"}.}
+\item{data_id_col}{Character string naming the ID column in \code{data}.  Default is \code{"id"}.}
 
-\item{data_plot_trait}{A data frame containing ID, variety, trait, and rank columns.}
+\item{data_trait_cols}{Optional character vector of specific trait-indicator columns
+in \code{data} to restrict scanning (overrides automatic selection by suffix).  Default \code{NULL}.}
 
-\item{data_plot_trait_id_col}{The name of the ID column in \code{data_plot_trait}. Default is \code{"id"}.}
+\item{carry_cols}{Optional character vector of column names in \code{data} to carry along
+into the output (e.g. blocking factors, metadata).  Default \code{NULL}.}
 
-\item{variety_col}{The name of the variety column in \code{data_plot_trait}.}
+\item{data_plot_trait}{A data frame in “plot–trait” format containing one row per
+(ID, variety, trait) with an associated \code{rank_col}.  Default \code{NULL}.}
 
-\item{trait_col}{The name of the trait column in \code{data_plot_trait}.}
+\item{data_plot_trait_id_col}{Character string naming the ID column in
+\code{data_plot_trait}.  Default is \code{"id"}.}
 
-\item{rank_col}{The name of the rank column in \code{data_plot_trait}.}
+\item{variety_col}{Character string naming the variety column in \code{data_plot_trait}.}
 
-\item{option_cols}{A character vector of column names in \code{data} that store the option labels (e.g. \code{"option_a"}, \code{"option_b"}, \code{"option_c"}).}
+\item{trait_col}{Character string naming the trait column in \code{data_plot_trait}.}
 
-\item{possible_ranks}{A character vector mapping to \code{option_cols}, indicating rank labels (e.g. \code{"A"}, \code{"B"}, \code{"C"}).}
+\item{rank_col}{Character string naming the rank column in \code{data_plot_trait}.}
 
-\item{trait_good}{A suffix string (e.g. \code{"_pos"}) used to identify columns in \code{data} where a variety is "preferred" for a trait. Default is \code{"_pos"}.}
+\item{option_cols}{Character vector of length three naming the option columns in
+\code{data} (e.g. \code{c("option_a", "option_b", "option_c")}).  Default is
+\code{c("option_a", "option_b", "option_c")}.}
 
-\item{trait_bad}{A suffix string (e.g. \code{"_neg"}) used to identify columns in \code{data} where a variety is "not preferred" for a trait. Default is \code{"_neg"}.}
+\item{possible_ranks}{Character vector of labels corresponding to \code{option_cols}
+(e.g. \code{c("A", "B", "C")}).  Default is \code{c("A", "B", "C")}.}
 
-\item{na_value}{A value used to indicate when a trait was not observed or is missing. Default is \code{"Not observed"}.}
+\item{trait_good}{Suffix (or full name) identifying columns in \code{data} where a
+variety is positively ranked for a trait (e.g. \code{"_pos"} or \code{"best"}).  Default \code{"_pos"}.}
+
+\item{trait_bad}{Suffix (or full name) identifying columns in \code{data} where a
+variety is negatively ranked for a trait (e.g. \code{"_neg"} or \code{"worst"}).  Default \code{"_neg"}.}
+
+\item{na_value}{Value used in \code{data} to indicate a missing or unobserved trait.
+Default is \code{"Not observed"}.}
 }
 \value{
-A tibble with the transformed Tricot data, containing columns:
-\itemize{
-\item \code{id}: Identifier for each observation.
-\item \code{dummy_variety}: (Optional). The dummy variable that variety is associated to.
-\item \code{rank}: The rank assigned to each variety.
-\item \code{variety}: The variety name.
-\item And a set of trait variables
+A tibble in tidy format with one row per (ID, trait, variety) combination,
+containing at least the following columns:
+\describe{
+\item{id}{Identifier for each trial or plot.}
+\item{dummy_variety}{Factor-coded option label corresponding to the variety (e.g. \code{"A"}, \code{"B"}, \code{"C"}).}
+\item{trait}{Name of the trait being ranked (when \code{data} input used).}
+\item{rank}{Numeric or character rank assigned to the variety.}
+\item{variety}{Name of the variety or option.}
+\item{<carry_cols>}{Any additional columns specified via \code{carry_cols}, carried through from \code{data}.}
 }
+Additional trait-specific columns will appear if both \code{data} and
+\code{data_plot_trait} are provided.
 }
 \description{
-This function transforms Tricot (Triadic Comparison of Technologies) data
-into a tidy format, assigning ranks based on trait evaluations.
-}
-\details{
-It supports input either as a single dataset (\code{data}) or as two datasets:
-one with trait-wise rankings (\code{data_plot_trait}) and one with option labels and traits.
-
-The function assumes a tricot setup where three options (e.g. crops, varieties) are ranked per trait.
-Rankings may be extracted from columns ending in a suffix such as \verb{_pos} or \verb{_neg}, or explicitly provided.
+Transforms Tricot (Triadic Comparison of Technologies) data into a tidy format,
+assigning ranks to varieties based on trait evaluations.  Supports input either
+as a single ID-level dataset (\code{data}) with option columns and trait indicators,
+or as a plot–trait–level dataset (\code{data_plot_trait}) with explicit variety,
+trait, and rank columns, or both.
 }
 \examples{
-library(gosset)
-# Read in tricot data from the `gosset` library
-cassava_pivot <- pivot_tricot(cassava)
+# Using ID-level data only, carrying a blocking factor
+df <- data.frame(
+  id         = 1:3,
+  block      = rep(1:3),
+  option_a   = c("x", "y", "z"),
+  option_b   = c("u", "v", "w"),
+  option_c   = c("m", "n", "o"),
+  colour_pos = c("A", "B", "C"),
+  taste_neg  = c("C", "B", "Not observed")
+)
+pivot_tricot(
+  data         = df,
+  data_id_col  = "id",
+  carry_cols   = "block",
+  option_cols  = c("option_a", "option_b", "option_c"),
+  trait_good   = "_pos",
+  trait_bad    = "_neg"
+)
 
-# Example using nicabean data - if we have Plot-Trait Level data
-data(nicabean)
-nicabean_by_id_item_trait <- nicabean$trial
-nicabean_by_id <- nicabean$covar 
-nicabean_by_plot <- pivot_tricot(data_plot_trait = nicabean_by_id_item_trait, # B
-                                       data_plot_trait_id_col = "id",
-                                       variety_col = "item",
-                                       trait_col = "trait",
-                                       rank_col = "rank")
+# Using plot–trait–level data only
+df_trait <- data.frame(
+  id     = rep(1:2, each = 3),
+  item   = rep(c("x","y","z"), times = 2),
+  trait  = rep("colour", 6),
+  rank   = rep(1:3, times = 2)
+)
+pivot_tricot(
+  data_plot_trait       = df_trait,
+  data_plot_trait_id_col = "id",
+  variety_col            = "item",
+  trait_col              = "trait",
+  rank_col               = "rank"
+)
 
-# Example using breadwheat data - if we have just ID-Level data 
-data(breadwheat)
-breadwheat_by_plot <- pivot_tricot(data = breadwheat,
-                                         data_id_col = "participant_name",
-                                         option_cols = c("variety_a", "variety_b", "variety_c"),
-                                         trait_good = "best", trait_bad = "_worst")
-
-# Example using nicabean data - if we have both data and data_plot_trait data
-nicabean_by_id$Vigor_pos = "A"
-nicabean_by_id$Vigor_neg = "C"
-nicabean_by_plot_2 <- pivot_tricot(data = nicabean_by_id,
-                                         data_id_col = "id",
-                                         option_cols = c("variety_a", "variety_b", "variety_c"),
-                                         data_plot_trait = nicabean_by_id_item_trait,
-                                         data_plot_trait_id_col = "id",
-                                         variety_col = "item",
-                                         trait_col = "trait",
-                                         rank_col = "rank")
-                                         
-
-# Example with beans data
-library(PlackettLuce)
-data(beans)
-beans$ID <- 1:nrow(beans)
-beans_by_plot <- pivot_tricot(data = beans,
-                                         data_id_col = "ID",
-                                         option_cols = c("variety_a", "variety_b", "variety_c"),
-                                         trait_bad = "worst", trait_good = "best")
 }

--- a/man/pivot_tricot.Rd
+++ b/man/pivot_tricot.Rd
@@ -23,99 +23,63 @@ pivot_tricot(
 }
 \arguments{
 \item{data}{A data frame containing ID-level Tricot data.  Must include an ID column
-(\code{data_id_col}) and three option columns (\code{option_cols}), plus trait indicator
-columns ending in \code{trait_good} or \code{trait_bad}, unless \code{data_plot_trait} is provided.}
+(data_id_col) and three option columns (option_cols), plus trait indicator
+columns ending in trait_good or trait_bad, unless data_plot_trait is provided.}
 
-\item{data_id_col}{Character string naming the ID column in \code{data}.  Default is \code{"id"}.}
+\item{data_id_col}{Character string naming the ID column in data.  Default is "id".}
 
 \item{data_trait_cols}{Optional character vector of specific trait-indicator columns
-in \code{data} to restrict scanning (overrides automatic selection by suffix).  Default \code{NULL}.}
+in data to restrict scanning (overrides automatic selection by suffix).  Default NULL.}
 
-\item{carry_cols}{Optional character vector of column names in \code{data} to carry along
-into the output (e.g. blocking factors, metadata).  Default \code{NULL}.}
+\item{carry_cols}{Optional character vector of column names in data to carry along
+into the output (e.g. blocking factors, metadata).  Default NULL.}
 
 \item{data_plot_trait}{A data frame in “plot–trait” format containing one row per
-(ID, variety, trait) with an associated \code{rank_col}.  Default \code{NULL}.}
+(ID, variety, trait) with an associated rank_col.  Default NULL.}
 
 \item{data_plot_trait_id_col}{Character string naming the ID column in
-\code{data_plot_trait}.  Default is \code{"id"}.}
+data_plot_trait.  Default is "id".}
 
-\item{variety_col}{Character string naming the variety column in \code{data_plot_trait}.}
+\item{variety_col}{Character string naming the variety column in data_plot_trait.}
 
-\item{trait_col}{Character string naming the trait column in \code{data_plot_trait}.}
+\item{trait_col}{Character string naming the trait column in data_plot_trait.}
 
-\item{rank_col}{Character string naming the rank column in \code{data_plot_trait}.}
+\item{rank_col}{Character string naming the rank column in data_plot_trait.}
 
 \item{option_cols}{Character vector of length three naming the option columns in
-\code{data} (e.g. \code{c("option_a", "option_b", "option_c")}).  Default is
-\code{c("option_a", "option_b", "option_c")}.}
+data (e.g. c("option_a", "option_b", "option_c")).  Default is
+c("option_a", "option_b", "option_c").}
 
-\item{possible_ranks}{Character vector of labels corresponding to \code{option_cols}
-(e.g. \code{c("A", "B", "C")}).  Default is \code{c("A", "B", "C")}.}
+\item{possible_ranks}{Character vector of labels corresponding to option_cols
+(e.g. c("A", "B", "C")).  Default is c("A", "B", "C").}
 
-\item{trait_good}{Suffix (or full name) identifying columns in \code{data} where a
-variety is positively ranked for a trait (e.g. \code{"_pos"} or \code{"best"}).  Default \code{"_pos"}.}
+\item{trait_good}{Suffix (or full name) identifying columns in data where a
+variety is positively ranked for a trait (e.g. "_pos" or "best").  Default "_pos".}
 
-\item{trait_bad}{Suffix (or full name) identifying columns in \code{data} where a
-variety is negatively ranked for a trait (e.g. \code{"_neg"} or \code{"worst"}).  Default \code{"_neg"}.}
+\item{trait_bad}{Suffix (or full name) identifying columns in data where a
+variety is negatively ranked for a trait (e.g. "_neg" or "worst").  Default "_neg".}
 
-\item{na_value}{Value used in \code{data} to indicate a missing or unobserved trait.
-Default is \code{"Not observed"}.}
+\item{na_value}{Value used in data to indicate a missing or unobserved trait.
+Default is "Not observed".}
 }
 \value{
 A tibble in tidy format with one row per (ID, trait, variety) combination,
 containing at least the following columns:
 \describe{
-\item{id}{Identifier for each trial or plot.}
-\item{dummy_variety}{Factor-coded option label corresponding to the variety (e.g. \code{"A"}, \code{"B"}, \code{"C"}).}
-\item{trait}{Name of the trait being ranked (when \code{data} input used).}
+\item{<data_id_col>}{Identifier for each trial or plot (column name retained).}
+\item{dummy_variety}{Factor-coded option label corresponding to the variety (e.g. "A", "B", "C").}
+\item{trait}{Name of the trait being ranked (when data input used).}
 \item{rank}{Numeric or character rank assigned to the variety.}
 \item{variety}{Name of the variety or option.}
-\item{<carry_cols>}{Any additional columns specified via \code{carry_cols}, carried through from \code{data}.}
+\item{<carry_cols>}{Any additional columns specified via carry_cols, carried through from data.}
 }
-Additional trait-specific columns will appear if both \code{data} and
-\code{data_plot_trait} are provided.
+Additional trait-specific columns will appear if both data and
+data_plot_trait are provided.
 }
 \description{
 Transforms Tricot (Triadic Comparison of Technologies) data into a tidy format,
 assigning ranks to varieties based on trait evaluations.  Supports input either
-as a single ID-level dataset (\code{data}) with option columns and trait indicators,
-or as a plot–trait–level dataset (\code{data_plot_trait}) with explicit variety,
+as a single ID-level dataset (data) with option columns and trait indicators,
+or as a plot–trait–level dataset (data_plot_trait) with explicit variety,
 trait, and rank columns, or both.
-}
-\examples{
-# Using ID-level data only, carrying a blocking factor
-df <- data.frame(
-  id         = 1:3,
-  block      = rep(1:3),
-  option_a   = c("x", "y", "z"),
-  option_b   = c("u", "v", "w"),
-  option_c   = c("m", "n", "o"),
-  colour_pos = c("A", "B", "C"),
-  taste_neg  = c("C", "B", "Not observed")
-)
-pivot_tricot(
-  data         = df,
-  data_id_col  = "id",
-  carry_cols   = "block",
-  option_cols  = c("option_a", "option_b", "option_c"),
-  trait_good   = "_pos",
-  trait_bad    = "_neg"
-)
-
-# Using plot–trait–level data only
-df_trait <- data.frame(
-  id     = rep(1:2, each = 3),
-  item   = rep(c("x","y","z"), times = 2),
-  trait  = rep("colour", 6),
-  rank   = rep(1:3, times = 2)
-)
-pivot_tricot(
-  data_plot_trait       = df_trait,
-  data_plot_trait_id_col = "id",
-  variety_col            = "item",
-  trait_col              = "trait",
-  rank_col               = "rank"
-)
-
 }


### PR DESCRIPTION

Be able to specify your variety names to override the current system of just detecting _a, _b, _c, etc.
Be able to specify your traits to override too. 
Ability to carry columns
Bug if Traits are factors
Do not rename the ID variable to ID
